### PR TITLE
fix: Add --repo option in order to correctly detect repository to add secret to

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rotates a HCP Terraform user token stored as a secret in a GitHub repository.
 
 | name | description | required | default |
 | --- | --- | --- | --- |
-| `github_token` | <p>GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional.</p> | `true` | `""` |
+| `github_token` | <p>GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write.</p> | `true` | `""` |
 | `github_secrets_name` | <p>Name of the secret in the repository secret store where the token will be written.</p> | `false` | `HCP_TERRAFORM_USER_TOKEN` |
 | `hcp_terraform_user_token` | <p>HCP Terraform user token to be rotated. This token must already exist and be saved as a repository secret before running this action.</p> | `true` | `""` |
 | `hcp_terraform_user_token_description` | <p>Description for the HCP Terraform user token. Must be the same for the original and new tokens.</p> | `false` | `github-token` |
@@ -26,7 +26,7 @@ This action is a `composite` action.
 - uses: bendwyer/action-rotate-hcp-terraform-user-token@v1
   with:
     github_token:
-    # GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional.
+    # GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write.
     #
     # Required: true
     # Default: ""

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rotates a HCP Terraform user token stored as a secret in a GitHub repository.
 
 | name | description | required | default |
 | --- | --- | --- | --- |
-| `github_token` | <p>GitHub token used for writing the HCP Terraform user token to the repository secret store.</p> | `false` | `${{ github.token }}` |
+| `github_token` | <p>GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional.</p> | `true` | `""` |
 | `github_secrets_name` | <p>Name of the secret in the repository secret store where the token will be written.</p> | `false` | `HCP_TERRAFORM_USER_TOKEN` |
 | `hcp_terraform_user_token` | <p>HCP Terraform user token to be rotated. This token must already exist and be saved as a repository secret before running this action.</p> | `true` | `""` |
 | `hcp_terraform_user_token_description` | <p>Description for the HCP Terraform user token. Must be the same for the original and new tokens.</p> | `false` | `github-token` |
@@ -26,10 +26,10 @@ This action is a `composite` action.
 - uses: bendwyer/action-rotate-hcp-terraform-user-token@v1
   with:
     github_token:
-    # GitHub token used for writing the HCP Terraform user token to the repository secret store.
+    # GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional.
     #
-    # Required: false
-    # Default: ${{ github.token }}
+    # Required: true
+    # Default: ""
 
     github_secrets_name:
     # Name of the secret in the repository secret store where the token will be written.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,22 @@ This action is a `composite` action.
 ```
 <!-- action-docs-all source="action.yml" project="bendwyer/action-rotate-hcp-terraform-user-token" version="v1" -->
 
+Commits
+-------
+
+[Commit headers](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit-header) are expected in order for version bumping to work correctly:
+
+- **build**: Changes that affect the build system or external dependencies
+- **ci**: Changes to CI configuration files and scripts
+- **docs**: Documentation only changes
+- **feat**: A new feature
+- **fix**: A bug fix
+- **perf**: A code change that improves performance
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **test**: Adding missing tests or correcting existing tests
+
 Resources
 ---------
 
 - [Changing Passwords and Updating Tokens Outside of the Terraform Cloud and Terraform Enterprise UI](https://support.hashicorp.com/hc/en-us/articles/4402342106003-Changing-Passwords-and-Updating-Tokens-Outside-of-the-Terraform-Cloud-and-Terraform-Enterprise-UI)
+- [Create or update a repository secret](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#create-or-update-a-repository-secret)

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: Ben Dwyer (github.com/bendwyer)
 
 inputs:
   github_token:
-    description: "GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional."
+    description: "GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write."
     required: true
   github_secrets_name:
     description: Name of the secret in the repository secret store where the token will be written.

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,8 @@ author: Ben Dwyer (github.com/bendwyer)
 
 inputs:
   github_token:
-    description: GitHub token used for writing the HCP Terraform user token to the repository secret store.
-    required: false
-    default: ${{ github.token }}
+    description: "GitHub token used for writing the HCP Terraform user token to the repository secret store. Requires the repository permission secrets:write. The repository permission environments:write is optional."
+    required: true
   github_secrets_name:
     description: Name of the secret in the repository secret store where the token will be written.
     required: false
@@ -86,7 +85,7 @@ runs:
           echo "Mask new token"
           echo "::add-mask::$NEW_TOKEN"
           echo "Write new token to repository secrets"
-          gh secret set $SECRETS_NAME --body "$NEW_TOKEN" --app actions
+          gh secret set $SECRETS_NAME --body "$NEW_TOKEN" --repo ${{ github.repository }} --app actions
         fi
         echo "Check if old user token should be deleted"
         if [[ $MATCHED_TOKEN_COUNT == 1 ]]


### PR DESCRIPTION
This PR adds the --repo option to the `gh secret set` command so the CLI knows where to write the secret. Previously this failed on repositories where no code checkout was perfomed before running this action.